### PR TITLE
Test version guessing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# custom
+_version.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+SHELL=/bin/bash
+DIRNAME := $(shell basename $$(pwd))
+SITEPKGS := $(shell python3 -c 'import site; print(site.getsitepackages()[0])')
+
+help:
+	@echo
+	@echo "Synopsis: make [ build clean vars version ]"
+	@echo
+
+vars:
+	@echo "DIRNAME: '${DIRNAME}'"
+	@echo "SITEPKGS: '${SITEPKGS}'"
+
+version: pkg_deps
+	python3 -m setuptools_scm
+
+build: pkg_deps
+	python3 -m build
+
+pkg_deps: ${SITEPKGS}/build ${SITEPKGS}/setuptools_scm
+
+${SITEPKGS}/build:
+	python3 -m pip install --upgrade build
+
+${SITEPKGS}/setuptools_scm:
+	python3 -m pip install --upgrade setuptools-scm
+
+clean:
+	rm -rf dist/
+	rm -rf ipf.egg-info/

--- a/ajlpypubtest/build_helper.py
+++ b/ajlpypubtest/build_helper.py
@@ -1,0 +1,23 @@
+from setuptools_scm.version import guess_next_version
+import time
+def mk_version( version ):
+    # setuptools_scm template options
+    # see also https://github.com/pypa/setuptools-scm/blob/main/src/setuptools_scm/version.py especially "def meta( ... )"
+    # '{branch}',
+    # '{dirty}',
+    # '{distance}',
+    # '{node}',
+    # '{node_date}',
+    # '{time}',
+    # SPEACIAL NAMES
+    # '{guessed}', #from version.py:format_next_version(...)
+
+    final = 'unknown'
+    if version.exact :
+        final = version.format_with( '{tag}' )
+    else :
+        # unix timestamp as dev qualifier, ensures it's always unique
+        # to comply with test.pypi.org requirement to NEVER re-use a version
+        fmt_str = '{guessed}.dev' + str(int(time.time()))
+        final = version.format_next_version( guess_next_version, fmt_str )
+    return final

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
-requires = [ "setuptools>=77.0.3", "setuptools-scm", ]
-build-backend = "setuptools.build_meta"
+requires = [ "setuptools >= 80", "setuptools-scm >= 8.3", ]
+build-backend = "setuptools.build_meta:__legacy__"
+# __legacy__ enables acces to function in the local package
+# https://setuptools-git-versioning.readthedocs.io/en/stable/options/version_callback.html
 
 [project]
 name = "ajlpypubtest"
@@ -30,5 +32,6 @@ readme = { file = [ "README.md" ] }
 
 [tool.setuptools_scm]
 version_file = "ajlpypubtest/_version.py"
-version_scheme = "guess-next-dev"  # this is the default
+# version_scheme = "guess-next-dev"  # this is the default
+version_scheme = "ajlpypubtest.build_helper:mk_version"
 local_scheme = "no-local-version"  # local version component not allowed on pypi


### PR DESCRIPTION
New versioning for dev branches, use "dev" + timestamp as the version string to guarantee unique version for publishing.